### PR TITLE
feat(subtypes): add sub-types to workload struct

### DIFF
--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -6,6 +6,7 @@ mod types;
 use crate::client::scheduler;
 
 use tokio::sync::mpsc;
+use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Server, Request, Response, Status};
 
@@ -40,25 +41,19 @@ impl SchedulingService for MySchedulingService {
                 WorkloadStatus {
                     name: "Workload 1".to_string(),
                     status_code: 0,
-                    message: "Workload 1 is running".to_string(),
+                    message: "Your workload is WAITING".to_string(),
                     ..Default::default()
                 },
                 WorkloadStatus {
                     name: "Workload 1".to_string(),
-                    status_code: 0,
-                    message: "Workload 1 is terminated".to_string(),
+                    status_code: 1,
+                    message: "Your workload is RUNNING".to_string(),
                     ..Default::default()
                 },
                 WorkloadStatus {
                     name: "Workload 2".to_string(),
-                    status_code: 0,
-                    message: "Workload 2 is running".to_string(),
-                    ..Default::default()
-                },
-                WorkloadStatus {
-                    name: "Workload 2".to_string(),
-                    status_code: 0,
-                    message: "Workload 2 is terminated".to_string(),
+                    status_code: 2,
+                    message: "Your workload is TERMINATED".to_string(),
                     ..Default::default()
                 },
             ];
@@ -68,6 +63,9 @@ impl SchedulingService for MySchedulingService {
                     .send(Ok(status))
                     .await
                     .expect("Failed to send status to stream");
+
+                // Attendre 10 secondes avant le prochain envoi
+                sleep(Duration::from_secs(10)).await;
             }
 
             sender

--- a/controller/src/routes/workloads.rs
+++ b/controller/src/routes/workloads.rs
@@ -10,6 +10,7 @@ use crate::{
     errors::ApiError,
 };
 use axum::Json;
+use log::info;
 use serde_json::{self, json, Value};
 use validator::Validate;
 
@@ -70,7 +71,7 @@ pub async fn post_workload(body: String) -> anyhow::Result<Json<Value>, ApiError
 
     let response = client.schedule_workload(request).await.unwrap();
 
-    println!("RESPONSE={:?}", response);
+    info!("RESPONSE={:?}", response);
     // TODO: Handle the grpc response and if OK save data and send response to cli
     Ok(Json(json!({"description": "Created"})))
 }

--- a/controller/src/routes/workloads.rs
+++ b/controller/src/routes/workloads.rs
@@ -40,7 +40,7 @@ pub async fn post_workload(body: String) -> anyhow::Result<Json<Value>, ApiError
     // Create a new Workload Request object out of the body
     let json_body: WorkloadRequest = serde_json::from_str(&body)?;
 
-    // Validate the request
+    // Validate if the workload request is valid
     json_body.validate()?;
 
     // Extract the env variable table
@@ -68,7 +68,9 @@ pub async fn post_workload(body: String) -> anyhow::Result<Json<Value>, ApiError
         workload: Some(workload),
     };
 
-    client.schedule_workload(request).await.unwrap();
+    let response = client.schedule_workload(request).await.unwrap();
+
+    println!("RESPONSE={:?}", response);
     // TODO: Handle the grpc response and if OK save data and send response to cli
     Ok(Json(json!({"description": "Created"})))
 }

--- a/controller/src/types/workload_request.rs
+++ b/controller/src/types/workload_request.rs
@@ -1,22 +1,36 @@
-use serde::Deserialize;
-use validator::Validate;
+use serde::{Deserialize, Serialize};
+use validator::{Validate, ValidationError};
 
 #[derive(Debug, Validate, Deserialize)]
 pub struct WorkloadRequest {
     pub version: String,
     pub workload: Workload,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum WorkloadKind {
+    Container,
+    Baremetal,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum WorkloadRegistry {
+    Docker,
+    Podman,
+    Ghcr,
+}
 #[derive(Debug, Validate, Deserialize)]
 pub struct Workload {
-    #[validate(length(min = 1))]
-    pub kind: String,
+    #[validate(custom = "validate_workload_kind")]
+    pub kind: WorkloadKind,
 
     #[validate(length(min = 1))]
     pub name: String,
 
     pub environment: Vec<String>,
 
-    pub registry: String,
+    #[validate(custom = "validate_workload_registry")]
+    pub registry: WorkloadRegistry,
 
     #[validate(length(min = 1))]
     pub image: String,
@@ -24,4 +38,19 @@ pub struct Workload {
     pub port: String,
 
     pub network: Vec<String>,
+}
+
+fn validate_workload_kind(kind: &WorkloadKind) -> Result<(), ValidationError> {
+    match kind {
+        WorkloadKind::Container => Ok(()),
+        WorkloadKind::Baremetal => Ok(()),
+    }
+}
+
+fn validate_workload_registry(registry: &WorkloadRegistry) -> Result<(), ValidationError> {
+    match registry {
+        WorkloadRegistry::Docker => Ok(()),
+        WorkloadRegistry::Podman => Ok(()),
+        WorkloadRegistry::Ghcr => Ok(()),
+    }
 }


### PR DESCRIPTION
# Summary

This pull request introduces a basic implementation for subtypes of the workload struct. Here are the key changes:

- We've introduced an enum to control the kind of the workload. This enum provides options for specifying whether the program is waiting for a 'container' or 'baremetal' workload.

- The registry field can also be controlled by an enum, unless we want to allow users to use their private hub repository.

## Other Changes

In addition to the above, there are a few other changes:

- I've implemented a fake time interval and changing status codes for each new WorkloadStatus responses.
- Some comments have been renamed for improved clarity. 